### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,58 +11,58 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-L6470			KEYWORD1
+L6470	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-AccCalc			KEYWORD2
-DecCalc			KEYWORD2
-convert			KEYWORD2
-free			KEYWORD2
-FSCalc			KEYWORD2
-GetParam		KEYWORD2
-getPos			KEYWORD2
-getStatus		KEYWORD2
-goHome			KEYWORD2
-goMark			KEYWORD2
-goTo			KEYWORD2
-goTo_DIR		KEYWORD2
-goUntil			KEYWORD2
-hardHiZ			KEYWORD2
-hardStop		KEYWORD2
-init			KEYWORD2
-IntSpdCalc		KEYWORD2
-isBusy			KEYWORD2
-L6470			KEYWORD2
-MaxSpdCalc		KEYWORD2
-MinSpdCalc		KEYWORD2
-move			KEYWORD2
-Param			KEYWORD2
-ParamHandler		KEYWORD2
-releaseSW		KEYWORD2
-resetDev		KEYWORD2
-resetPos		KEYWORD2
-run			KEYWORD2
-setAcc			KEYWORD2
-setAsHome		KEYWORD2
-setCurrent		KEYWORD2
-setDec			KEYWORD2
-SetLowSpeedOpt		KEYWORD2
-setMark			KEYWORD2
-setMaxSpeed		KEYWORD2
-setMicroSteps		KEYWORD2
-setMinSpeed		KEYWORD2
-setOverCurrent		KEYWORD2
-setParam		KEYWORD2
-setStallCurrent		KEYWORD2
+AccCalc	KEYWORD2
+DecCalc	KEYWORD2
+convert	KEYWORD2
+free	KEYWORD2
+FSCalc	KEYWORD2
+GetParam	KEYWORD2
+getPos	KEYWORD2
+getStatus	KEYWORD2
+goHome	KEYWORD2
+goMark	KEYWORD2
+goTo	KEYWORD2
+goTo_DIR	KEYWORD2
+goUntil	KEYWORD2
+hardHiZ	KEYWORD2
+hardStop	KEYWORD2
+init	KEYWORD2
+IntSpdCalc	KEYWORD2
+isBusy	KEYWORD2
+L6470	KEYWORD2
+MaxSpdCalc	KEYWORD2
+MinSpdCalc	KEYWORD2
+move	KEYWORD2
+Param	KEYWORD2
+ParamHandler	KEYWORD2
+releaseSW	KEYWORD2
+resetDev	KEYWORD2
+resetPos	KEYWORD2
+run	KEYWORD2
+setAcc	KEYWORD2
+setAsHome	KEYWORD2
+setCurrent	KEYWORD2
+setDec	KEYWORD2
+SetLowSpeedOpt	KEYWORD2
+setMark	KEYWORD2
+setMaxSpeed	KEYWORD2
+setMicroSteps	KEYWORD2
+setMinSpeed	KEYWORD2
+setOverCurrent	KEYWORD2
+setParam	KEYWORD2
+setStallCurrent	KEYWORD2
 setThresholdSpeed	KEYWORD2
-softFree		KEYWORD2
-softStop		KEYWORD2
-SpdCalc			KEYWORD2
-Step_Clock		KEYWORD2
-Xfer			KEYWORD2
+softFree	KEYWORD2
+softStop	KEYWORD2
+SpdCalc	KEYWORD2
+Step_Clock	KEYWORD2
+Xfer	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords