### PR TITLE
Param() update/fix

### DIFF
--- a/L6470/L6470.cpp
+++ b/L6470/L6470.cpp
@@ -390,8 +390,8 @@ unsigned long L6470::Param(unsigned long value, const byte bit_len) {
   //  store it until return time.
   unsigned long ret_val;
   switch (byte_len) {
-    case 3: ret_val = long(Xfer((byte)(value >> 16))) << 16; break;
-    case 2: ret_val = long(Xfer((byte)(value >> 8))) << 8; break;
+    case 3: ret_val = long(Xfer((byte)(value >> 16))) << 16;
+    case 2: ret_val = long(Xfer((byte)(value >> 8))) << 8;
     case 1: ret_val = Xfer((byte)value); break;
     default: ret_val = 0; break;
   }


### PR DESCRIPTION
Change Param() to be similar to the other multi-byte routines so that it will automatically transfer all the bits of a paramter.